### PR TITLE
Fix django module not found errors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn movie_tracker.wsgi
+web: gunicorn movie_tracker.movie_tracker.wsgi
 tailwind: python manage.py tailwind build

--- a/asgi.py
+++ b/asgi.py
@@ -8,11 +8,8 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 """
 
 import os
-import sys
-
-
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'movie_tracker.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'movie_tracker.movie_tracker.settings')
 
 application = get_asgi_application()

--- a/manage.py
+++ b/manage.py
@@ -2,11 +2,14 @@
 import os
 import sys
 
-# Add outer movie_tracker folder to sys.path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'movie_tracker'))
+"""Project management entrypoint.
+
+This project uses a nested Django package at `movie_tracker/movie_tracker`.
+Rely on Django's module import via DJANGO_SETTINGS_MODULE instead of manual path hacks.
+"""
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'movie_tracker.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'movie_tracker.movie_tracker.settings')
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)
 

--- a/movie_tracker/movie_tracker/settings.py
+++ b/movie_tracker/movie_tracker/settings.py
@@ -36,7 +36,7 @@ ALLOWED_HOSTS = [h.strip() for h in config("ALLOWED_HOSTS", default=_default_all
 # Trust Heroku domains for CSRF by default; override via env if needed
 CSRF_TRUSTED_ORIGINS = [o.strip() for o in config("CSRF_TRUSTED_ORIGINS", default="https://*.herokuapp.com").split(",") if o.strip()]
 
-WSGI_APPLICATION = 'movie_tracker.wsgi.application'
+WSGI_APPLICATION = 'movie_tracker.movie_tracker.wsgi.application'
 
 
 # Application definition
@@ -84,7 +84,7 @@ if DEBUG:
         "django_browser_reload.middleware.BrowserReloadMiddleware",
     ]
 
-ROOT_URLCONF = 'movie_tracker.urls'
+ROOT_URLCONF = 'movie_tracker.movie_tracker.urls'
 
 TEMPLATES = [
     {
@@ -102,7 +102,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'movie_tracker.wsgi.application'
+WSGI_APPLICATION = 'movie_tracker.movie_tracker.wsgi.application'
 
 
 TMDB_API_KEY = config("TMDB_API_KEY")

--- a/movie_tracker/movie_tracker/wsgi.py
+++ b/movie_tracker/movie_tracker/wsgi.py
@@ -1,11 +1,6 @@
 import os
-import sys
-
-# Add outer movie_tracker folder to sys.path
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'movie_tracker'))
-
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'movie_tracker.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'movie_tracker.movie_tracker.settings')
 
 application = get_wsgi_application()


### PR DESCRIPTION
Correct Django module import paths and Gunicorn WSGI target to resolve deployment `ModuleNotFoundError` and `KeyError` due to nested project structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a02e572-b0d9-4db5-b695-40c24947e467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a02e572-b0d9-4db5-b695-40c24947e467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 47838c5a6aaf35f8eee594c1af8562a7b36224a5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->