### PR TITLE
Changes from background agent bc-cf67fe0c-36ab-49a0-a245-5a2c4d2b5259

### DIFF
--- a/movie_tracker/core/apps.py
+++ b/movie_tracker/core/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'core'
+    name = 'movie_tracker.core'

--- a/movie_tracker/core/views.py
+++ b/movie_tracker/core/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
 import requests
 
-from movies.models import Review
+from movie_tracker.movies.models import Review
 from django.db import models
 
 from .models import Profile

--- a/movie_tracker/movie_tracker/settings.py
+++ b/movie_tracker/movie_tracker/settings.py
@@ -51,8 +51,8 @@ INSTALLED_APPS = [
     'allauth.account',
     'tailwind',
     'theme',
-    'core',
-    'movies',
+    'movie_tracker.core',
+    'movie_tracker.movies',
 ]
 
 if DEBUG:

--- a/movie_tracker/movie_tracker/urls.py
+++ b/movie_tracker/movie_tracker/urls.py
@@ -21,8 +21,8 @@ from django.conf import settings
 urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
-    path('', include('core.urls')),
-    path('movie/', include('movies.urls', namespace='movies'))
+    path('', include('movie_tracker.core.urls')),
+    path('movie/', include('movie_tracker.movies.urls', namespace='movies'))
 ]
 
 if settings.DEBUG:

--- a/movie_tracker/movies/apps.py
+++ b/movie_tracker/movies/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 class MoviesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'movies'
+    name = 'movie_tracker.movies'


### PR DESCRIPTION
Correct Django app import paths to resolve module import errors on Heroku.

The Django project's nested structure caused `ModuleNotFoundError` for `core` and `movies` apps, and subsequently `KeyError: 'tailwind'`, during Heroku deployment. This PR updates `INSTALLED_APPS`, `AppConfig` names, URL includes, and cross-app imports to use fully qualified package paths, enabling Django to correctly discover and load the applications.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf67fe0c-36ab-49a0-a245-5a2c4d2b5259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf67fe0c-36ab-49a0-a245-5a2c4d2b5259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

