### PR TITLE
Fix rimraf not found error

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn movie_tracker.movie_tracker.wsgi
-tailwind: python manage.py tailwind build
+tailwind: python manage.py tailwind install && python manage.py tailwind build


### PR DESCRIPTION
Add `tailwind install` to the Procfile to ensure Node.js dependencies are installed before building Tailwind CSS.

The `tailwind` dyno was crashing because the `npm run build:clean` script, part of the `tailwind build` process, relies on `rimraf`, which is a Node.js package. This package was not available because `npm install` (which `tailwind install` executes) was not run, leading to `sh: 1: rimraf: not found` errors. Explicitly running `tailwind install` resolves this by ensuring all necessary Node.js dependencies are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a55dc95-837e-4683-84f5-e042a8fd9682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a55dc95-837e-4683-84f5-e042a8fd9682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepend `tailwind install` to the Procfile's `tailwind` command to install Node deps before building Tailwind CSS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad213868069ac1ca2342deebde82dc411c92fa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->