### PR TITLE
Deploy and tailwind build process

### DIFF
--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "scripts": {
     "start": "npm run dev",
-    "build": "npm run build:clean && npm run build:tailwind",
-    "build:clean": "rimraf ../static/css/dist",
+    "build": "npm run build:prepare && npm run build:tailwind",
+    "build:prepare": "node -e \"const fs=require('fs');const p=require('path');const d=p.resolve(__dirname,'../static/css/dist');fs.rmSync(d,{recursive:true,force:true});fs.mkdirSync(d,{recursive:true});\"",
     "build:tailwind": "cross-env NODE_ENV=production postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
     "dev": "cross-env NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch"
   },
@@ -20,7 +20,6 @@
     "postcss-cli": "^11.0.1",
     "postcss-nested": "^7.0.2",
     "postcss-simple-vars": "^7.0.1",
-    "rimraf": "^6.0.1",
     "tailwindcss": "^4.1.11"
   }
 }


### PR DESCRIPTION
Replace `rimraf` with a portable Node.js script to fix Tailwind CSS build failures on Heroku.

The `tailwind.1` dyno on Heroku was crashing because the `rimraf` command was not found in the execution environment, preventing the `build:clean` script from running. This change replaces `rimraf` with a cross-platform Node.js command to ensure the `theme/static/css/dist` directory is properly managed before building Tailwind CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcc0b1eb-57cd-4a0b-a0f5-ef554b5fe747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dcc0b1eb-57cd-4a0b-a0f5-ef554b5fe747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

