### PR TITLE
Build tailwind css and handle errors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn movie_tracker.movie_tracker.wsgi
-tailwind: python manage.py tailwind install && python manage.py tailwind build
+tailwind: python manage.py tailwind install && npm ci --prefix theme/static_src --include=dev && python manage.py tailwind build

--- a/theme/static_src/.npmrc
+++ b/theme/static_src/.npmrc
@@ -1,0 +1,1 @@
+production=false

--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -6,8 +6,8 @@
     "start": "npm run dev",
     "build": "npm run build:prepare && npm run build:tailwind",
     "build:prepare": "node -e \"const fs=require('fs');const p=require('path');const d=p.resolve(__dirname,'../static/css/dist');fs.rmSync(d,{recursive:true,force:true});fs.mkdirSync(d,{recursive:true});\"",
-    "build:tailwind": "cross-env NODE_ENV=production postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
-    "dev": "cross-env NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch"
+    "build:tailwind": "NODE_ENV=production postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
+    "dev": "NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch"
   },
   "keywords": [],
   "author": "",
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
     "daisyui": "^5.0.43",
-    "cross-env": "^7.0.3",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "postcss-nested": "^7.0.2",


### PR DESCRIPTION
Enable devDependency installation for the Tailwind build on Heroku and remove `cross-env` to fix dyno crashes.

The Heroku tailwind dyno was failing because `rimraf` and `cross-env` binaries were not found, as Heroku's default behavior is to only install production dependencies. This PR ensures devDependencies are installed and replaces `cross-env` with native environment variable setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a584d01-a907-4116-b8ac-c25c4ae7227e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a584d01-a907-4116-b8ac-c25c4ae7227e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

