### PR TITLE
Changes from background agent bc-645f74b9-aade-46fb-a89e-453e5deed271

### DIFF
--- a/movie_tracker/templates/base.html
+++ b/movie_tracker/templates/base.html
@@ -1,5 +1,5 @@
 {% load account %}
-{% load tailwind_tags %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -7,8 +7,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{% endblock %} | MB </title>
-    {% tailwind_preload_css %}
-    {% tailwind_css %}
+    <link rel="preload" href="{% static 'css/dist/styles.css' %}" as="style">
+    <link rel="stylesheet" href="{% static 'css/dist/styles.css' %}">
 </head>
 <body class="relative min-h-screen bg-[#020617] text-white">
 


### PR DESCRIPTION
Update `base.html` to use `{% static %}` for Tailwind CSS to resolve 404 errors on Heroku.

The `{% tailwind_css %}` tag generated an unhashed path, which caused 404 errors when WhiteNoise's manifest storage was active in production. Switching to `{% static %}` ensures the correct hashed file is served.

---
<a href="https://cursor.com/background-agent?bcId=bc-645f74b9-aade-46fb-a89e-453e5deed271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-645f74b9-aade-46fb-a89e-453e5deed271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e2930dd89aad66856f64abfc1c8b75d69f29a636. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->